### PR TITLE
Aggregate daily stats

### DIFF
--- a/src/core/domain/Endpoint/Endpoint.ts
+++ b/src/core/domain/Endpoint/Endpoint.ts
@@ -5,11 +5,24 @@ import { strict as assert } from 'assert';
 import EndpointUrl from './EndpointUrl';
 import EndpointName from './EndpointName';
 
-const TOTAL_LATEST_CHECKS = 50;
+const TOTAL_LATEST_CHECKS = 90;
 const FAILURE = 'FAILURE';
 const OK = 'OK';
 
 const AVAILABILITY_DECIMALS = 4;
+
+type Incident = {
+  incidentDate: Date,
+  duration: number,
+  reason: string
+}
+
+type Status = {
+  date: Date
+  incidents: Incident[]
+  averageResponseTime: number
+  totalSuccessfulHealthChecks: number
+};
 
 export default class Endpoint {
   private id: EndpointId;
@@ -18,18 +31,18 @@ export default class Endpoint {
   private name: EndpointName;
   
   private updated: Date;
-  private latestHealthChecks: [{ date: Date, status: string, timeInMs: number }];
+  private dailyStatuses: Status[];
   private firstHealthCheckDate: Date;
   private downtimeMinutes: number;
   private serviceDownDate: Date;
 
-  constructor(id: EndpointId, userId: UserId, url: EndpointUrl, name: EndpointName, updated: Date, lastHealthChecks, firstHealthCheckDate, downtimeMinutes, serviceDownDate) {
+  constructor(id: EndpointId, userId: UserId, url: EndpointUrl, name: EndpointName, updated: Date, dailyStatuses, firstHealthCheckDate, downtimeMinutes, serviceDownDate) {
     this.id = id;
     this.userId = userId;
     this.url = url;
     this.name = name;
     this.updated = updated;
-    this.latestHealthChecks = lastHealthChecks;
+    this.dailyStatuses = dailyStatuses;
     this.firstHealthCheckDate = firstHealthCheckDate;
     this.downtimeMinutes = downtimeMinutes;
     this.serviceDownDate = serviceDownDate || null;
@@ -48,7 +61,7 @@ export default class Endpoint {
   getUrl() { return this.url; }
   getName() { return this.name; }
   getUpdated() { return this.updated; }
-  getLatestHealthChecks() { return this.latestHealthChecks; }
+  getDailyStatuses() { return this.dailyStatuses; }
   getFirstHealthCheckDate() { return this.firstHealthCheckDate }
   getServiceDownDate() { return this.serviceDownDate; }
   getDowntimeMinutes() { return this.downtimeMinutes }
@@ -64,7 +77,7 @@ export default class Endpoint {
     this.increaseDowntimeMinutes();
 
     if (eventData.isFailed()) {
-      this.serviceDownDate = new Date();
+      this.serviceDownDate = eventData.date;
     }
     else this.serviceDownDate = null;
   }
@@ -78,12 +91,51 @@ export default class Endpoint {
   }
 
   private updateLastHealthChecks(eventData: EndpointUpdatedEventData) {
-    this.latestHealthChecks.unshift({
-      date: eventData.date,
-      status: eventData.time === 0 ? FAILURE : OK,
-      timeInMs: eventData.time
-    });
-    this.latestHealthChecks.splice(TOTAL_LATEST_CHECKS);
+
+    const addStatus = (eventData: EndpointUpdatedEventData, status: Status) => {
+      if (eventData.isFailed()) {
+        if (this.getServiceDownDate() === null || status.incidents.length === 0) {
+          status.incidents.push({
+            incidentDate: eventData.date,
+            duration: 0,
+            reason: ''
+          })
+        }
+        else {
+          const lastIncident = status.incidents[0];
+          const diffInMs = eventData.date.getTime() - this.getServiceDownDate().getTime();
+          lastIncident.duration = diffInMs / (60 * 1000);
+        }
+      }
+    }
+
+    if (this.dailyStatuses.length > 0) {
+      const lastStatus = this.dailyStatuses[0];
+      if (this.isSameDay(lastStatus.date, eventData.date)) {
+        if (!eventData.isFailed()) {
+          lastStatus.averageResponseTime = ((lastStatus.averageResponseTime * lastStatus.totalSuccessfulHealthChecks) + eventData.time) / (lastStatus.totalSuccessfulHealthChecks + 1);
+          lastStatus.totalSuccessfulHealthChecks += 1;
+        }
+        addStatus(eventData, lastStatus);
+      }
+    }
+    else {
+      const lastStatus = {
+        date: eventData.date,
+        averageResponseTime: eventData.isFailed()? 0 : eventData.time,
+        incidents: [] as Incident[],
+        totalSuccessfulHealthChecks: eventData.isFailed()? 0 : 1
+      };
+      addStatus(eventData, lastStatus);
+      this.dailyStatuses.unshift(lastStatus);
+      this.dailyStatuses.splice(TOTAL_LATEST_CHECKS);
+    }
+  }
+
+  private isSameDay(date1: Date, date2: Date): boolean {
+    return  date1.getUTCDate() === date2.getUTCDate() &&
+            date1.getUTCMonth() === date2.getUTCMonth() &&
+            date1.getUTCFullYear() === date2.getUTCFullYear();
   }
 
   private updateFirstHealthCheckDate() {

--- a/src/core/domain/Endpoint/Endpoint.ts
+++ b/src/core/domain/Endpoint/Endpoint.ts
@@ -5,9 +5,8 @@ import { strict as assert } from 'assert';
 import EndpointUrl from './EndpointUrl';
 import EndpointName from './EndpointName';
 
+const HEALCHECK_INTERVAL_MINUTES = 1;
 const TOTAL_LATEST_CHECKS = 90;
-const FAILURE = 'FAILURE';
-const OK = 'OK';
 
 const AVAILABILITY_DECIMALS = 4;
 
@@ -86,9 +85,7 @@ export default class Endpoint {
 
   private increaseDowntimeMinutes() {
     if (this.serviceDownDate) {
-      const diffSeconds = (Date.now() - this.serviceDownDate.getTime()) / 1000;
-      const diffMinutes = diffSeconds / 60;
-      this.downtimeMinutes += diffMinutes;
+      this.downtimeMinutes += HEALCHECK_INTERVAL_MINUTES;
     }
   }
 

--- a/src/core/domain/Endpoint/Endpoint.ts
+++ b/src/core/domain/Endpoint/Endpoint.ts
@@ -77,7 +77,9 @@ export default class Endpoint {
     this.increaseDowntimeMinutes();
 
     if (eventData.isFailed()) {
-      this.serviceDownDate = eventData.date;
+      if (this.serviceDownDate === null) {
+        this.serviceDownDate = eventData.date;
+      }
     }
     else this.serviceDownDate = null;
   }

--- a/src/core/infrastructure/Endpoint/EndpointMongoDocument.ts
+++ b/src/core/infrastructure/Endpoint/EndpointMongoDocument.ts
@@ -5,7 +5,12 @@ export interface EndpointMongoDocument extends Document {
   userId: string; 
   url: string;
   name: string;
-  latestHealthChecks: [{status: string, timeInMs: number, date: Date }];
+  latestDailyStatuses: [{
+    date: Date, 
+    incidents: [], 
+    averageResponseTime: number, 
+    totalSuccessfulHealthChecks: number
+  }];
   updated: Date;
   downtimeMinutes: number;
   firstHealthCheckDate: Date;
@@ -17,7 +22,14 @@ export const EndpointMongoSchema = new Schema({
   userId: { type:String, required: true },
   url: { type:String, required: true },
   name: { type:String, required: true },
-  latestHealthChecks: [{ _id: false, status: String, timeInMs: Number, date: Date }],
+  latestDailyStatuses: [{ 
+    _id: false,
+    date: Date, 
+    incidents: [], 
+    averageResponseTime: Number, 
+    totalSuccessfulHealthChecks: Number
+
+  }],
   updated: { type: Date },
   downtimeMinutes: { type: Number, default: 0 },
   firstHealthCheckDate: { type: Date },

--- a/src/core/infrastructure/Endpoint/EndpointStatusMongoRepository.ts
+++ b/src/core/infrastructure/Endpoint/EndpointStatusMongoRepository.ts
@@ -14,7 +14,7 @@ export default class EndpointStatusMongoRepository implements EndpointStatusRepo
       host: endpoint.getUrl().getValue(),
       userId: endpoint.getUserId().getValue(),
       name: endpoint.getName().getValue(),
-      latestHealthChecks: endpoint.getLatestHealthChecks(),
+      latestDailyStatuses: endpoint.getDailyStatuses(),
       updated: endpoint.getUpdated(),
       firstHealthCheckDate: endpoint.getFirstHealthCheckDate(),
       serviceDownDate: endpoint.getServiceDownDate(),
@@ -31,7 +31,7 @@ export default class EndpointStatusMongoRepository implements EndpointStatusRepo
       new EndpointUrl(document.url),
       new EndpointName(document.name),
       document.updated, 
-      document.latestHealthChecks,
+      document.latestDailyStatuses,
       document.firstHealthCheckDate,
       document.downtimeMinutes,
       document.serviceDownDate
@@ -46,7 +46,7 @@ export default class EndpointStatusMongoRepository implements EndpointStatusRepo
       new EndpointUrl(document.url),
       new EndpointName(document.name),
       document.updated, 
-      document.latestHealthChecks,
+      document.latestDailyStatuses,
       document.firstHealthCheckDate,
       document.downtimeMinutes,
       document.serviceDownDate
@@ -63,7 +63,7 @@ export default class EndpointStatusMongoRepository implements EndpointStatusRepo
       new EndpointUrl(document.url),
       new EndpointName(document.name),
       document.updated, 
-      document.latestHealthChecks,
+      document.latestDailyStatuses,
       document.firstHealthCheckDate,
       document.downtimeMinutes,
       document.serviceDownDate

--- a/src/core/infrastructure/http/express/ApiController.ts
+++ b/src/core/infrastructure/http/express/ApiController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import container from '../../DependencyInjection';
 import FindEndpointsForUser from '../../../usecase/FindEndpointsForUser';
-import Endpoint from '../../../domain/Endpoint/Endpoint';
+import Endpoint, {  } from '../../../domain/Endpoint/Endpoint';
 
 const findEndpointsForUser = container.get('core.usecase.FindEndpointsForUser', FindEndpointsForUser);
 
@@ -15,7 +15,7 @@ export default class ApiController {
 
       const response = {
         status: 'HEALTH',
-        endpoints: this.map(endpoints)
+        endpoints: this.mapEndpoints(endpoints)
       }
       res.status(200).json(response);
     }
@@ -24,12 +24,22 @@ export default class ApiController {
     }
   }
 
-  private map(endpoints: Endpoint[]) {
+  private mapEndpoints(endpoints: Endpoint[]) {
     return endpoints.map(endpoint => ({
       name: endpoint.getName(),
       uptime: endpoint.getAvailability(),
-      statuses: endpoint.getDailyStatuses()
+      statuses: this.mapDailyStats(endpoint.getDailyStatuses())
     }))
+  }
+
+  private mapDailyStats(dailyStats: any) {
+    return dailyStats.map(status => {
+      return {
+        date: status.date,
+        responseTime: status.averageResponseTime,
+        totalIncidents: status.incidents.length
+      }
+    })
   }
 
 }

--- a/src/core/infrastructure/http/express/ApiController.ts
+++ b/src/core/infrastructure/http/express/ApiController.ts
@@ -28,7 +28,7 @@ export default class ApiController {
     return endpoints.map(endpoint => ({
       name: endpoint.getName(),
       uptime: endpoint.getAvailability(),
-      statuses: this.mapDailyStats(endpoint.getDailyStatuses())
+      dailyStats: this.mapDailyStats(endpoint.getDailyStatuses())
     }))
   }
 

--- a/src/core/infrastructure/http/express/ApiController.ts
+++ b/src/core/infrastructure/http/express/ApiController.ts
@@ -28,7 +28,7 @@ export default class ApiController {
     return endpoints.map(endpoint => ({
       name: endpoint.getName(),
       uptime: endpoint.getAvailability(),
-      statuses: endpoint.getLatestHealthChecks()
+      statuses: endpoint.getDailyStatuses()
     }))
   }
 

--- a/src/core/infrastructure/http/express/ApiController.ts
+++ b/src/core/infrastructure/http/express/ApiController.ts
@@ -37,9 +37,26 @@ export default class ApiController {
       return {
         date: status.date,
         responseTime: status.averageResponseTime,
-        totalIncidents: status.incidents.length
+        totalIncidents: status.incidents.length,
+        status: this.calculateHealth(status.incidents)
       }
     })
+  }
+  
+  //TODO: move this to the domain
+  calculateHealth(incidents: any[]) {
+    const totalIncidentsDuration = () => {
+      return incidents.reduce((total, incident) => {
+        return total + incident.duration;
+      }, 0)
+    }
+    if (incidents.length > 50 || totalIncidentsDuration() > 4*60) {
+      return 'ERROR';
+    }
+    else if (incidents.length > 10 || totalIncidentsDuration() > 10) {
+      return 'WARNING';
+    }
+    else return 'OK';
   }
 
 }

--- a/src/core/infrastructure/http/express/ApiController.ts
+++ b/src/core/infrastructure/http/express/ApiController.ts
@@ -33,27 +33,32 @@ export default class ApiController {
   }
 
   private mapDailyStats(dailyStats: any) {
+    const calculateIncidentsDuration = (incidents) => {
+      return incidents.reduce((total, incident) => {
+        return total + incident.duration;
+      }, 0)
+    }
+
+
     return dailyStats.map(status => {
+      const totalIncidentsDuration = calculateIncidentsDuration(status.incidents);
       return {
         date: status.date,
         responseTime: status.averageResponseTime,
         totalIncidents: status.incidents.length,
-        status: this.calculateHealth(status.incidents)
+        totalDowntime: totalIncidentsDuration,
+        status: this.calculateHealth(status.incidents, totalIncidentsDuration)
       }
     })
   }
   
   //TODO: move this to the domain
-  calculateHealth(incidents: any[]) {
-    const totalIncidentsDuration = () => {
-      return incidents.reduce((total, incident) => {
-        return total + incident.duration;
-      }, 0)
-    }
-    if (incidents.length > 50 || totalIncidentsDuration() > 4*60) {
+  calculateHealth(incidents: any[], totalIncidentsDuration: number) {
+    
+    if (incidents.length > 50 || totalIncidentsDuration > 4*60) {
       return 'ERROR';
     }
-    else if (incidents.length > 10 || totalIncidentsDuration() > 10) {
+    else if (incidents.length > 10 || totalIncidentsDuration > 10) {
       return 'WARNING';
     }
     else return 'OK';

--- a/test/core/domain/Endpoint/EndpointStatus_spec.ts
+++ b/test/core/domain/Endpoint/EndpointStatus_spec.ts
@@ -40,16 +40,91 @@ describe('EndpointStatus entity', () => {
     it('should add a health check information', () => {
       const endpoint = Endpoint.create(userId, url, endpointName);
       endpoint.updateWithHealthCheck(new EndpointUpdatedEventData('id', 'ip', 'host', 123, new Date()));
-      should(endpoint.getLatestHealthChecks()).not.be.empty();
+      should(endpoint.getDailyStatuses()).not.be.empty();
     })
     
-    it('should keep the latest 50 health checks', () => {
-      const initialLastChecks = new Array(50);
-      initialLastChecks.fill({}, 0, 49);
-      const endpoint = new Endpoint(randomEndpointId, userId, url, endpointName, new Date(), initialLastChecks, new Date(), 0, null);
-      endpoint.updateWithHealthCheck(new EndpointUpdatedEventData('id', 'ip', 'host', 123, new Date()));
-      should(endpoint.getLatestHealthChecks()).have.lengthOf(50);
+    it('should keep the latest 90 daily statuses', () => {
+      const now = Date.now();
+      const day = 3600 * 24 * 1000;
+      const initialDailyStatuses = Array.from({length: 90}).map((o, i) => {
+        const d = new Date(now - (i * day));
+        return {
+          date: d
+        }
+      });
+      const tomorrow = new Date(now + day);
+      const endpoint = new Endpoint(randomEndpointId, userId, url, endpointName, tomorrow, initialDailyStatuses, new Date(), 0, null);
+      const eventData = new EndpointUpdatedEventData('id', 'ip', 'host', 123, new Date());
+      
+      endpoint.updateWithHealthCheck(eventData);
+      
+      should(endpoint.getDailyStatuses()).have.lengthOf(90);
     })
+
+    it('should aggregate the health checks in the same day', () => {
+      const today = new Date();
+      const endpoint = new Endpoint(randomEndpointId, userId, url, endpointName, new Date(), [], new Date(), 0, null);
+      endpoint.updateWithHealthCheck(new EndpointUpdatedEventData('id', 'ip', 'host', 123, today));
+      endpoint.updateWithHealthCheck(new EndpointUpdatedEventData('id', 'ip', 'host', 321, today));
+      should(endpoint.getDailyStatuses()).have.lengthOf(1);
+    })
+
+    it('should add the incident for the day', () => {
+      const endpoint = Endpoint.create(userId, url, endpointName);
+      const failedHealthCheckEvent = new EndpointUpdatedEventData('id', null, 'host', 0, new Date());      
+      endpoint.updateWithHealthCheck(failedHealthCheckEvent);
+
+      const todayStatus = endpoint.getDailyStatuses().shift();
+
+      should(todayStatus.incidents).have.lengthOf(1);
+      should(todayStatus.totalSuccessfulHealthChecks).be.eql(0);
+    });
+
+    it('should add the incident to an existing aggregated day', () => {
+      const today = new Date();
+      const initialDailyStatuses = [{
+        date: today,
+        incidents: [],
+        averageResponseTime: 0,
+        totalSuccessfulHealthChecks: 0
+      }]
+      const endpoint = new Endpoint(randomEndpointId, userId, url, endpointName, new Date(), initialDailyStatuses, new Date(), 0, null);
+      const failedHealthCheckEvent = new EndpointUpdatedEventData('id', null, 'host', 0, new Date());      
+      endpoint.updateWithHealthCheck(failedHealthCheckEvent);
+
+      const todayStatus = endpoint.getDailyStatuses().shift();
+      
+      should(todayStatus.incidents).have.lengthOf(1);
+      should(todayStatus.totalSuccessfulHealthChecks).be.eql(0);
+    })
+
+    it('should accumulate multiple failed health checks', () => {
+      const endpoint = Endpoint.create(userId, url, endpointName);
+      const now = new Date();
+      const aMinuteAgo = new Date(now.getTime() - 60*1000);
+      const failedHealthCheckEvent1 = new EndpointUpdatedEventData('id', null, 'host', 0, aMinuteAgo);
+      const failedHealthCheckEvent2 = new EndpointUpdatedEventData('id', null, 'host', 0, now);
+      endpoint.updateWithHealthCheck(failedHealthCheckEvent1);
+      endpoint.updateWithHealthCheck(failedHealthCheckEvent2);
+
+      const todayStatus = endpoint.getDailyStatuses().shift();
+      should(todayStatus.incidents).have.lengthOf(1);
+      should(todayStatus.incidents[0].duration).greaterThanOrEqual(1).and.below(2);
+    });
+
+    it('should recaculate the AVG response time on every update', () => {
+      const endpoint = Endpoint.create(userId, url, endpointName);
+      const now = new Date();
+      const successfullHealthCheckEvent1 = new EndpointUpdatedEventData('id', 'ip', 'host', 200, now);
+      const successfullHealthCheckEvent2 = new EndpointUpdatedEventData('id', 'ip', 'host', 150, now);
+      const successfullHealthCheckEvent3 = new EndpointUpdatedEventData('id', 'ip', 'host', 160, now);
+      endpoint.updateWithHealthCheck(successfullHealthCheckEvent1);
+      endpoint.updateWithHealthCheck(successfullHealthCheckEvent2);
+      endpoint.updateWithHealthCheck(successfullHealthCheckEvent3);
+
+      const todayStatus = endpoint.getDailyStatuses().shift();
+      should(todayStatus.averageResponseTime).be.eql(170)
+    });
 
     it('should update the first health check date', () => {
       const endpoint = Endpoint.create(userId, url, endpointName);

--- a/test/core/domain/Endpoint/EndpointStatus_spec.ts
+++ b/test/core/domain/Endpoint/EndpointStatus_spec.ts
@@ -143,9 +143,10 @@ describe('EndpointStatus entity', () => {
       const lastFailedDate = new Date(now - (60 * 1000));
       const initialMinutesDown = 10;
       const endpoint = new Endpoint(randomEndpointId, userId, url, endpointName, new Date(), [], new Date(), initialMinutesDown, lastFailedDate);
+      
       endpoint.updateWithHealthCheck(new EndpointUpdatedEventData('id', null, 'host', 1, new Date()));
+      
       endpoint.getDowntimeMinutes().should.be.greaterThan(initialMinutesDown);
-      endpoint.getServiceDownDate().getTime().should.be.greaterThanOrEqual(now);
     })
 
     it('should restore the service down date when the API is OK again', () => {
@@ -158,6 +159,16 @@ describe('EndpointStatus entity', () => {
       endpoint.getDowntimeMinutes().should.be.greaterThan(initialMinutesDown);
       should.not.exist(endpoint.getServiceDownDate());
     });
+
+    it('should keep the service down date after multiple failed checks', () => {
+      const now = Date.now();
+      const lastFailedDate = new Date(now - (60 * 1000));
+      const initialMinutesDown = 10;
+      const endpoint = new Endpoint(randomEndpointId, userId, url, endpointName, new Date(), [], new Date(), initialMinutesDown, lastFailedDate);
+      endpoint.updateWithHealthCheck(new EndpointUpdatedEventData('id', null, null, 0, new Date()));
+      
+      should(endpoint.getServiceDownDate()).be.eql(lastFailedDate);
+    })
   });
 
   context('Availability calculation', () => {

--- a/test/core/domain/Endpoint/EndpointStatus_spec.ts
+++ b/test/core/domain/Endpoint/EndpointStatus_spec.ts
@@ -140,23 +140,33 @@ describe('EndpointStatus entity', () => {
 
     it('should increase the downtime minutes after the first fail', () => {
       const now = Date.now();
-      const lastFailedDate = new Date(now - (60 * 1000));
-      const initialMinutesDown = 10;
+      const lastFailedDate = new Date(now - (10 * 60 * 1000));
+      const initialMinutesDown = 9;
       const endpoint = new Endpoint(randomEndpointId, userId, url, endpointName, new Date(), [], new Date(), initialMinutesDown, lastFailedDate);
       
       endpoint.updateWithHealthCheck(new EndpointUpdatedEventData('id', null, 'host', 1, new Date()));
       
-      endpoint.getDowntimeMinutes().should.be.greaterThan(initialMinutesDown);
+      endpoint.getDowntimeMinutes().should.be.eql(10);
+    })
+
+    it('should increase the downtime minutes when there was errors in the past', () => {
+      const lastFailedDate = new Date(Date.now() - (60 * 1000));;
+      const initialMinutesDown = 20;
+      const endpoint = new Endpoint(randomEndpointId, userId, url, endpointName, new Date(), [], new Date(), initialMinutesDown, lastFailedDate);
+      
+      endpoint.updateWithHealthCheck(new EndpointUpdatedEventData('id', null, 'host', 0, new Date()));
+      
+      endpoint.getDowntimeMinutes().should.be.eql(21);
     })
 
     it('should restore the service down date when the API is OK again', () => {
       const now = Date.now();
-      const lastFailedDate = new Date(now - (60 * 1000));
-      const initialMinutesDown = 10;
+      const lastFailedDate = new Date(now - (10 * 60 * 1000));
+      const initialMinutesDown = 9;
       const endpoint = new Endpoint(randomEndpointId, userId, url, endpointName, new Date(), [], new Date(), initialMinutesDown, lastFailedDate);
       endpoint.updateWithHealthCheck(new EndpointUpdatedEventData('id', 'ip', 'host', 100, new Date()));
       
-      endpoint.getDowntimeMinutes().should.be.greaterThan(initialMinutesDown);
+      endpoint.getDowntimeMinutes().should.be.eql(10);
       should.not.exist(endpoint.getServiceDownDate());
     });
 

--- a/test/core/usecase/SaveEndpointUpdatedEvent_spec.ts
+++ b/test/core/usecase/SaveEndpointUpdatedEvent_spec.ts
@@ -42,7 +42,7 @@ describe('Scenario: Saved endpoint updated event', () => {
     const saveHealthCheck = new SaveHealthCheck(healthCheckMongoRepository, endpointRepository);
     await saveHealthCheck.execute(event);
 
-    should(endpointStatus.getLatestHealthChecks()).not.be.empty();
+    should(endpointStatus.getDailyStatuses()).not.be.empty();
     verify(mockEndpointStatusMongoRepository.save(anything())).once();
   })
 


### PR DESCRIPTION
In this PR we replace the `latestHealthChecks` fields with the latest checks for the endpoint by `dailyStatuses` which keeps the aggregated data for the latest 90 days.

It's important to note that now the read model has a lot of logic in order to aggregate the data without querying the model, so we need to move certain responsibilities to their own classes. This will come into a new PR.